### PR TITLE
Base change from ubuntu to arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN git clone -b using https://github.com/higanworks/ngx_mruby.git --depth 1
 RUN wget http://labs.frickle.com/files/ngx_cache_purge-2.3.tar.gz \
 && tar xvzf ngx_cache_purge-2.3.tar.gz
 
-ENV NGINX_SRC_VER=nginx-1.9.9
+ENV NGINX_SRC_VER=nginx-1.9.10
 ENV NGINX_CONFIG_OPT_ENV --with-debug --with-http_geoip_module --with-http_v2_module --with-http_stub_status_module --with-http_ssl_module --prefix=/usr/local/nginx --with-http_realip_module --with-http_addition_module --with-http_sub_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_random_index_module --with-http_secure_link_module --add-module=/usr/local/src/ngx_cache_purge-2.3
 
 RUN mkdir -p /usr/local/share/GeoIP

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN pacman -S openssl wget git make ruby hiredis libcap bison \
  autoconf gcc \
  pcre2 geoip curl markdown libmariadbclient \
  -yy --noconfirm \
-&& rm -rf /var/lib/pacman /var/cache/pacman /tmp/* /var/tmp/*
+&& rm -rf /var/lib/pacman/local/* /var/cache/pacman /tmp/* /var/tmp/*
 
 WORKDIR /usr/local/src
 RUN git clone -b using https://github.com/higanworks/ngx_mruby.git --depth 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM ubuntu:14.04
+FROM base/archlinux:2015.06.01
 MAINTAINER sawanoboriyu@higanworks.com
 
-RUN apt-get -y update \
-&& apt-get -y install autoconf build-essential git curl wget \
-      bison libcurl4-openssl-dev libhiredis-dev libmarkdown2-dev libcap-dev libcgroup-dev libpcre3 libpcre3-dev libmysqlclient-dev rake \
-&& apt-get -y build-dep nginx openssl \
-&& apt-get clean \
-&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN pacman -S openssl wget git make ruby hiredis libcap bison \
+ autoconf gcc \
+ pcre2 geoip curl markdown libmariadbclient \
+ -yy --noconfirm \
+&& rm -rf /var/lib/pacman /var/cache/pacman /tmp/* /var/tmp/*
 
 WORKDIR /usr/local/src
 RUN git clone -b using https://github.com/higanworks/ngx_mruby.git --depth 1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+
+https://hub.docker.com/r/giraffi/docker-nginx-mruby-base/


### PR DESCRIPTION
ngx_mruby | Nginx::SSL.new requires openssl 1.0.2e or later.
