### PR TITLE
In nginx 1.11.5, it can omit --without-stream_access_module from configure option

### DIFF
--- a/config/configure.sh
+++ b/config/configure.sh
@@ -18,6 +18,5 @@
  --with-stream \
  --with-stream_ssl_module \
  --without-stream_limit_conn_module \
- --without-stream_access_module \
  --add-module=../ngx_mruby/dependence/ngx_devel_kit
 


### PR DESCRIPTION
see also:
- [Update nginx to v1\.11\.5 by hfm · Pull Request \#220 · matsumotory/ngx\_mruby](https://github.com/matsumotory/ngx_mruby/pull/220/f)
- [In nginx 1\.11\.5, it can omit \-\-without\-stream\_access\_module option from test\.sh by hfm · Pull Request \#223 · matsumotory/ngx\_mruby](https://github.com/matsumotory/ngx_mruby/pull/223)